### PR TITLE
Update README to use og served from website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A collection of beautifully designed, ready-to-use UI blocks for Svelte 5, built with Tailwind CSS v4 and shadcn-svelte.
 
-![image](./static/og.png)
+![image](https://sv-blocks.vercel.app/og.png)
 
 ## Overview
 


### PR DESCRIPTION
This will fix the image not appearing on external sites like jsrepo.com.

P.S. We can either add a changeset to this one or include it on the next release.